### PR TITLE
Fix GitHub Pages deployment issue

### DIFF
--- a/front/geniarthub_react_refactory/index.html
+++ b/front/geniarthub_react_refactory/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>

--- a/front/geniarthub_react_refactory/package.json
+++ b/front/geniarthub_react_refactory/package.json
@@ -25,5 +25,6 @@
     "eslint-plugin-react-refresh": "^0.4.13",
     "globals": "^15.11.0",
     "vite": "^5.4.9"
-  }
+  },
+  "homepage": "https://kydocode.github.io/GeniArtHub-react-refactor/front/geniarthub_react_refactory/"
 }

--- a/front/geniarthub_react_refactory/src/main.jsx
+++ b/front/geniarthub_react_refactory/src/main.jsx
@@ -1,11 +1,12 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <BrowserRouter basename="/GeniArtHub-react-refactor/">
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )
-
-// Update the import statement for `App` to use the new `App.jsx` file done ?

--- a/front/geniarthub_react_refactory/vite.config.js
+++ b/front/geniarthub_react_refactory/vite.config.js
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/GeniArtHub-react-refactor/front/geniarthub_react_refactory/',
   plugins: [react()],
 })


### PR DESCRIPTION
Update the project configuration to fix the blank page issue when deployed on GitHub Pages.

* **index.html**
  - Update the script reference to use a relative path that works for GitHub Pages.

* **vite.config.js**
  - Add a `base` property set to `/GeniArtHub-react-refactor/front/geniarthub_react_refactory/` for correct routing on GitHub Pages.

* **package.json**
  - Add a `homepage` field set to `https://kydocode.github.io/GeniArtHub-react-refactor/front/geniarthub_react_refactory/`.

* **main.jsx**
  - Update the `BrowserRouter` to use the `basename` property for handling the base URL for GitHub Pages.

