### PR TITLE
Fix deployment URL for GeniArtHub React refactor

### DIFF
--- a/front/geniarthub_react_refactory/index.html
+++ b/front/geniarthub_react_refactory/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="./src/main.jsx"></script>
+    <script type="module" src="/GeniArtHub-react-refactor/front/geniarthub_react_refactory/src/main.jsx"></script>
   </body>
 </html>

--- a/front/geniarthub_react_refactory/src/main.jsx
+++ b/front/geniarthub_react_refactory/src/main.jsx
@@ -1,12 +1,9 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <BrowserRouter basename="/GeniArtHub-react-refactor/">
-      <App />
-    </BrowserRouter>
+    <App />
   </StrictMode>,
 )


### PR DESCRIPTION
Update the script reference in `index.html` and remove `BrowserRouter` in `main.jsx`.

* **index.html**
  - Update the script tag to `<script type="module" src="/GeniArtHub-react-refactor/front/geniarthub_react_refactory/src/main.jsx"></script>`.

* **main.jsx**
  - Remove the `BrowserRouter` component wrapping the `App` component.
  - Update the `createRoot` call to directly render the `App` component.

